### PR TITLE
adding commit query changes module

### DIFF
--- a/library/tetration_scope.py
+++ b/library/tetration_scope.py
@@ -17,10 +17,9 @@ version_added: '2.8'
 description:
 - Enables management of Cisco Tetration scopes
 - Enables creation, modification, deletion of scopes
-- For updates of C(short_query) parameter requires calling for `tetration_scope_update_apply` module after all shory query updates are done.
+- For updates of C(short_query) parameter requires calling for `tetration_scope_commit_query_changes` module after all shory query updates are done.
 
 notes:
-- Supports check mode
 - If the ID is set, uses the C(short_name) field as if you were going to update the object
 - If you pass in an ID that does not exist, the module will error out
 

--- a/library/tetration_scope_commit_query_changes.py
+++ b/library/tetration_scope_commit_query_changes.py
@@ -1,0 +1,121 @@
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: tetration_scope_commit_query_changes
+
+short_description: Commits changes made to short query parameters
+
+version_added: "2.8"
+
+description:
+    - "When changes are made to a scopes short query, they are not actually commited"
+    - "This modules allows you to commit the changes.  "
+    - "Supported options are to do it now or to queue the job"
+
+notes:
+    - "If the command successfully runs, always returns as changed even if no short queries need updating"
+
+options:
+    root_app_scope_id:
+        description:
+            - The App Scope ID for which any short queries that need updating will be updated
+            - Updates the app scope id listed and any app scope id's under it
+        required: true
+        type: string
+    sync:
+        description:
+            - Controls whether to run the job immediatly (True) or to queue the job
+        required: false
+        default: false
+        type: bool
+
+extends_documentation_fragment: tetration_doc_common
+
+author:
+    - Joe Jacobs (@joej164)
+'''
+
+EXAMPLES = '''
+# Pass in a message
+- name: Commit scope query changes via queuing
+  tetration_scope_commit_query_changes:
+    root_app_scope_id: abc123
+    provider:
+      host: "https://tetration-cluster.company.com"
+      api_key: 1234567890QWERTY
+      api_secret: 1234567890QWERTY
+
+- name: Commit scope query changes immediately
+  tetration_scope_commit_query_changes:
+    root_app_scope_id: abc123
+    sync: true
+    provider:
+      host: "https://tetration-cluster.company.com"
+      api_key: 1234567890QWERTY
+      api_secret: 1234567890QWERTY
+'''
+
+RETURN = '''
+success:
+    description: Boolean value describing whether the command successfully ran or not 
+    type: bool
+    returned: always
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.tetration_constants import TETRATION_API_SCOPES
+from ansible.module_utils.tetration_constants import TETRATION_PROVIDER_SPEC
+from ansible.module_utils.tetration import TetrationApiModule
+
+
+def run_module():
+    # define available arguments/parameters a user can pass to the module
+    module_args = dict(
+        root_app_scope_id=dict(type='str', required=True),
+        sync=dict(type='bool', required=False, default=False),
+        provider=dict(type='dict', options=TETRATION_PROVIDER_SPEC)
+    )
+
+    result = dict(
+        changed=False,
+        object={},
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+
+    tet_module = TetrationApiModule(module)
+    all_scopes_response = tet_module.run_method('GET', TETRATION_API_SCOPES)
+    all_scopes_lookup = {s['id']: s['short_name'] for s in all_scopes_response}
+
+    if module.params['root_app_scope_id'] and module.params['root_app_scope_id'] not in all_scopes_lookup.keys():
+        error_message = "`root_app_scope_id` passed into the module does not exist."
+        module.fail_json(msg=error_message, searched_scope=module.params['root_app_scope_id'])
+
+    req_payload = {
+        'root_app_scope_id': module.params['root_app_scope_id'],
+        'sync': module.params['sync']
+    }
+
+    route = f"{TETRATION_API_SCOPES}/commit_dirty"
+    response = tet_module.run_method('POST', route, req_payload=req_payload)
+
+    result['object'] = response
+    result['changed'] = True
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/module_utils/tetration.py
+++ b/module_utils/tetration.py
@@ -125,7 +125,7 @@ class TetrationApiModule(TetrationApiBase):
 
     def _post(self, target, params, req_payload):
         resp = self.rc.post(target, json_body=json.dumps(req_payload))
-        if resp.status_code / 100 == 2:
+        if resp.status_code in tetration_constants.TETRATION_API_SUCCESS_CODES:
             try:
                 return resp.json()
             except ValueError:
@@ -135,7 +135,7 @@ class TetrationApiModule(TetrationApiBase):
 
     def _put(self, target, params, req_payload):
         resp = self.rc.put(target, json_body=json.dumps(req_payload))
-        if resp.status_code / 100 == 2:
+        if resp.status_code in tetration_constants.TETRATION_API_SUCCESS_CODES:
             try:
                 return resp.json()
             except ValueError:

--- a/molecule/tetration_scope_commit_query_changes/converge.yml
+++ b/molecule/tetration_scope_commit_query_changes/converge.yml
@@ -1,0 +1,154 @@
+---
+- name: Converge
+  hosts: localhost
+  connection: local
+
+  tasks:
+    - name: "Include ansible-module"
+      include_role:
+        name: "ansible-module"
+
+    - name: read variables from the environment that are set in the molecule.yml
+      set_fact:
+        ansible_host: "{{ lookup('env', 'TETRATION_SERVER_ENDPOINT') }}"
+        api_key: "{{ lookup('env', 'TETRATION_API_KEY') }}"
+        api_secret: "{{ lookup('env', 'TETRATION_API_SECRET') }}"
+      no_log: True 
+
+    - name: put the variables in the required format
+      set_fact:
+        provider_info:
+          api_key: "{{ api_key }}"
+          api_secret: "{{ api_secret }}"
+          server_endpoint: "{{ ansible_host }}"
+      no_log: True 
+
+    - name: set test variables
+      set_fact:
+        root_scope_id: 5ce71503497d4f2c23af85b7
+# -----
+
+    - name: Test - module fails with invalid root scope 
+      tetration_scope_commit_query_changes:
+        root_app_scope_id: 123abc 
+        provider: "{{ provider_info }}"
+      ignore_errors: true
+      register: output
+    
+    - name: Output - module fails with invalid root scope 
+      debug:
+        var: output
+
+    - name: Verify - module fails with invalid root scope 
+      assert:
+        that:
+          - output.failed == true
+          - output.changed == false
+# -----
+
+    - name: Test - no changes made async
+      tetration_scope_commit_query_changes:
+        root_app_scope_id: "{{ root_scope_id }}" 
+        provider: "{{ provider_info }}"
+      register: output
+
+    - name: Output - no changes made
+      debug:
+        var: output
+
+    - name: Verify - no changes made
+      assert:
+        that:
+          - output.object.success == true 
+# -----
+
+    - name: Test - no changes made sync
+      tetration_scope_commit_query_changes:
+        root_app_scope_id: "{{ root_scope_id }}" 
+        sync: true
+        provider: "{{ provider_info }}"
+      register: output
+
+    - name: Output - no changes made sync
+      debug:
+        var: output
+
+    - name: Verify - no changes made sync
+      assert:
+        that:
+          - output.object.success == true 
+# -----
+
+    - name: Test - Verify can commit short query changes
+      tetration_scope:
+        short_name: CICD Test Scope
+        parent_app_scope_id: "{{ root_scope_id }}"
+        short_query:
+          type: subnet
+          field: ip
+          value: "10.0.0.0/16"
+        provider: "{{ provider_info }}"
+        state: present
+      register: output
+
+    - name: Output - Verify can commit short query changes
+      debug:
+        var: output
+
+    - name: Output - Verify short query is not dirty 
+      assert:
+        that: output.object.dirty == false
+
+    - name: Test - Make short query dirty 
+      tetration_scope:
+        short_name: CICD Test Scope
+        parent_app_scope_id: "{{ root_scope_id }}"
+        short_query:
+          type: subnet
+          field: ip
+          value: "11.0.0.0/16"
+        provider: "{{ provider_info }}"
+        state: present
+      register: output
+
+    - name: Output - Make short query dirty 
+      debug:
+        var: output
+
+    - name: Verify - Make short query dirty 
+      assert:
+        that: output.object.dirty == true 
+
+    - name: Test - Commit short query changes
+      tetration_scope_commit_query_changes:
+        root_app_scope_id: "{{ root_scope_id }}" 
+        provider: "{{ provider_info }}"
+      register: output 
+    
+    - name: Verify - Commit short query changes
+      assert:
+        that: output.object.success == true 
+
+    - name: Test - Check if scope not dirty 
+      tetration_scope:
+        short_name: CICD Test Scope
+        parent_app_scope_id: "{{ root_scope_id }}"
+        short_query:
+          type: subnet
+          field: ip
+          value: "11.0.0.0/16"
+        provider: "{{ provider_info }}"
+        state: present
+      register: output
+
+    - name: Verify - Check if scope not dirty 
+      assert:
+        that: output.object.dirty == false
+
+    - name: Cleanup - Check if scope not dirty 
+      tetration_scope:
+        short_name: CICD Test Scope
+        parent_app_scope_id: "{{ root_scope_id }}"
+        provider: "{{ provider_info }}"
+        state: absent 
+      register: output

--- a/molecule/tetration_scope_commit_query_changes/molecule.yml
+++ b/molecule/tetration_scope_commit_query_changes/molecule.yml
@@ -1,0 +1,34 @@
+---
+dependency:
+  name: galaxy
+platforms:
+  - name: instance
+    image: docker.io/pycontribs/centos:8
+    pre_build_image: true
+
+# ${PATH} added to the lint block is to fix an issue with molecule 3.0.7
+# https://github.com/ansible-community/molecule/issues/2781
+lint: |
+  set -e
+  PATH=${PATH}
+  yamllint molecule/
+  ansible-lint molecule/
+  
+provisioner:
+  name: ansible
+  env:
+    TETRATION_API_KEY: ${TETRATION_API_KEY}
+    TETRATION_API_SECRET: ${TETRATION_API_SECRET}
+    TETRATION_SERVER_ENDPOINT: ${TETRATION_SERVER_ENDPOINT}
+verifier:
+  name: ansible
+
+scenario:
+  test_sequence:
+    - lint
+    - converge
+  converge_sequence:
+    - lint
+    - converge
+  check_sequence:
+    - lint


### PR DESCRIPTION
- adds module to allow the committing of changes to short query fields
- updates to `tetration.py` and `tetration_constants.py` to allow for dealing with html return codes other than 200
- adding molecule tests for the new module